### PR TITLE
fix: remove unused storage permission from manifest

### DIFF
--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -6,7 +6,6 @@
   "permissions": [
     "activeTab",
     "tabs",
-    "storage",
     "tabCapture",
     "offscreen"
   ],


### PR DESCRIPTION
## Summary
- Remove unused `storage` permission from Chrome extension manifest
- Reduces permission footprint following principle of least privilege

## Test plan
- [x] Extension still loads without errors
- [x] All existing functionality remains intact
- [x] No console errors related to storage access

🤖 Generated with [Claude Code](https://claude.ai/code)