### PR TITLE
Add Chrome Web Store installation link to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,14 @@ The bot requires the following permissions:
 
 ### Step 2: Install the Chrome Extension
 
+#### Option A: Chrome Web Store (Recommended)
+
+🎉 **[Install Trunecord from Chrome Web Store](https://chromewebstore.google.com/detail/trunecord/dhmegdkoembgmlhekieedhkilbnjmjee)**
+
+Just click the link above and click "Add to Chrome" - it's that easy!
+
+#### Option B: Manual Installation (For Developers)
+
 1. Download the latest `trunecord-extension.zip` from the releases
 2. Extract the ZIP file to a folder on your computer
 3. Open Chrome and navigate to `chrome://extensions/`


### PR DESCRIPTION
## Summary
- Add official Chrome Web Store link as the primary installation method
- Keep manual installation option for developers
- Improve user onboarding experience

## Changes
- Added Chrome Web Store link: https://chromewebstore.google.com/detail/trunecord/dhmegdkoembgmlhekieedhkilbnjmjee
- Reorganized installation section with two options:
  - Option A: Chrome Web Store (Recommended)
  - Option B: Manual Installation (For Developers)

## Test plan
- [x] Verify Chrome Web Store link is working
- [ ] Check README renders correctly on GitHub
- [ ] Confirm installation instructions are clear

🤖 Generated with [Claude Code](https://claude.ai/code)