### PR TITLE
Security: Sanitize URLs in log output to prevent sensitive data exposure

### DIFF
--- a/go-client/internal/browser/browser_test.go
+++ b/go-client/internal/browser/browser_test.go
@@ -1,0 +1,78 @@
+package browser
+
+import (
+	"testing"
+)
+
+func TestSanitizeURLForLog(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "HTTP URL with query and fragment",
+			input:    "http://localhost:8080/auth/callback?token=secret&guilds=data#section",
+			expected: "http://localhost:8080/auth/callback",
+		},
+		{
+			name:     "HTTPS URL with sensitive query params",
+			input:    "https://example.com/oauth?client_id=123&client_secret=abc&code=xyz",
+			expected: "https://example.com/oauth",
+		},
+		{
+			name:     "URL with userinfo (username:password)",
+			input:    "https://user:password@example.com/api",
+			expected: "https://example.com/api",
+		},
+		{
+			name:     "URL with port number",
+			input:    "http://localhost:3000/path",
+			expected: "http://localhost:3000/path",
+		},
+		{
+			name:     "Data URL scheme",
+			input:    "data:text/plain;base64,SGVsbG8sIFdvcmxkIQ==",
+			expected: "data:<redacted>",
+		},
+		{
+			name:     "JavaScript URL scheme",
+			input:    "javascript:alert('XSS')",
+			expected: "javascript:<redacted>",
+		},
+		{
+			name:     "Mailto URL scheme",
+			input:    "mailto:user@example.com?subject=Secret",
+			expected: "mailto:<redacted>",
+		},
+		{
+			name:     "Relative URL",
+			input:    "/auth/callback?token=secret",
+			expected: "<relative-url>",
+		},
+		{
+			name:     "Invalid URL",
+			input:    "://invalid url",
+			expected: "<invalid-url>",
+		},
+		{
+			name:     "Simple HTTP URL",
+			input:    "http://example.com",
+			expected: "http://example.com",
+		},
+		{
+			name:     "HTTPS URL with path",
+			input:    "https://api.example.com/v1/users",
+			expected: "https://api.example.com/v1/users",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := sanitizeURLForLog(tt.input)
+			if result != tt.expected {
+				t.Errorf("sanitizeURLForLog(%q) = %q, want %q", tt.input, result, tt.expected)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- Add URL sanitization to prevent OAuth codes and tokens from appearing in logs
- Addresses CodeRabbit security review comment about sensitive data in logs

## Security Fix
**Issue**: URLs containing OAuth codes, tokens, and other sensitive query parameters were being logged in plain text
**Solution**: Added `sanitizeURLForLog` function that strips query parameters and fragments before logging

## Changes
- Added `sanitizeURLForLog` function to remove sensitive parts of URLs
- Applied sanitization to all browser opening log statements in `browser.go`
- Preserves the base URL for debugging while removing sensitive data

## Test Plan
- [x] URLs are logged without query parameters
- [x] OAuth flow still works correctly
- [x] No sensitive data appears in logs

## Example
**Before**: `Attempting to open browser at http://localhost:48766/auth/callback?token=eyJhbGc...&guilds=[...]`
**After**: `Attempting to open browser at http://localhost:48766/auth/callback`

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- 新機能
  - なし
- バグ修正
  - ログに含まれるURLからクエリやフラグメント、認証情報などを除去するマスキングを追加し、機密情報の露出リスクを低減。
  - 各プラットフォームでのURL処理がマスキングに準拠するよう統一。
- リファクタ
  - 内部の引数名とログ出力を整理し、安全なログ出力に調整。外部向けAPIの互換性に影響なし。
- テスト
  - マスキング関数の単体テストを追加し、様々なURL形式で挙動を検証。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->